### PR TITLE
[WIP] Add interactors functionality

### DIFF
--- a/campy/graphics/gwindow.py
+++ b/campy/graphics/gwindow.py
@@ -381,6 +381,9 @@ class GWindow:
         _platform.Platform().gwindow_clear(self)  # Remove from background layer.
         self._top.clear()  # Remove from foreground layer.
 
+    def clear_canvas(self):
+        _platform.Platform().gwindow_clear_canvas(self)
+
     def add(self, gobj, x=None, y=None):
         """Add a :class:`GObject` to the foreground layer of this :class:`GWindow`.
 

--- a/campy/gui/ginteractors.py
+++ b/campy/gui/ginteractors.py
@@ -256,7 +256,7 @@ class GTextField(GInteractor):
         _platform.Platform().gtextfield_set_enter_event(self, function)
 
     def __str__(self):
-        return "GTextField(text={}, label={}, width={})".format(self.text, self.label, self.width)
+        return "GTextField(text={}, width={})".format(self.text, self.width)
 
 
 class GChooser(GInteractor):

--- a/campy/gui/ginteractors.py
+++ b/campy/gui/ginteractors.py
@@ -228,7 +228,7 @@ class GTextField(GInteractor):
     Hitting RETURN in a text field generates a :class:`GActionEvent`.
     """
 
-    def __init__(self, width=10):
+    def __init__(self, label, width=10):
         """Create a text field with a maximum width.
 
         A :class:`GActionEvent` is generated whenever the user presses the
@@ -238,6 +238,8 @@ class GTextField(GInteractor):
         """
         super().__init__(self)
         self._width = width
+        self.label = label
+
         _platform.Platform().gtextfield_constructor(self)
 
     @property
@@ -249,8 +251,12 @@ class GTextField(GInteractor):
     def text(self, content):
         _platform.Platform().gtextfield_set_text(self, content)
 
+    def onenter(self, fn):
+        """Set event handler for return key"""
+        _platform.Platform().gtextfield_set_enter_event(self, fn)
+
     def __str__(self):
-        return "GTextField(text={}, width={})".format(self.text, self.width)
+        return "GTextField(text={}, label={}, width={})".format(self.text, self.label, self.width)
 
 
 class GChooser(GInteractor):

--- a/campy/gui/ginteractors.py
+++ b/campy/gui/ginteractors.py
@@ -130,15 +130,14 @@ class GButton(GInteractor):
         except ValueError:
             return False
 
-    def _click(self, event):
+    def _click(self):
         """Default click implementation doesn't do anything."""
         for listener in self._listeners:
-            listener(event)
+            listener()
 
     def click(self):
         # Make an event to pass to click handler.
-        event = GActionEvent(None, None, None)
-        self._click(event)
+        self._click()
 
 
 class GCheckBox(GInteractor):

--- a/campy/gui/ginteractors.py
+++ b/campy/gui/ginteractors.py
@@ -238,7 +238,7 @@ class GTextField(GInteractor):
         """
         super().__init__(self)
         self._width = width
-        self.label = label
+        self._label = label
 
         _platform.Platform().gtextfield_constructor(self)
 

--- a/campy/gui/ginteractors.py
+++ b/campy/gui/ginteractors.py
@@ -251,9 +251,9 @@ class GTextField(GInteractor):
     def text(self, content):
         _platform.Platform().gtextfield_set_text(self, content)
 
-    def onenter(self, fn):
+    def add_enter_handler(self, function):
         """Set event handler for return key"""
-        _platform.Platform().gtextfield_set_enter_event(self, fn)
+        _platform.Platform().gtextfield_set_enter_event(self, function)
 
     def __str__(self):
         return "GTextField(text={}, label={}, width={})".format(self.text, self.label, self.width)

--- a/campy/private/backends/backend_base.py
+++ b/campy/private/backends/backend_base.py
@@ -162,6 +162,7 @@ class GraphicsBackendBase(abc.ABC):
     def gtextfield_constructor(self, gtextfield, num_chars): pass
     def gtextfield_get_text(self, gtextfield): pass
     def gtextfield_set_text(self, gtextfield, text): pass
+    def gtextfield_set_enter_event(self, gtextfield, fn): pass
     def gchooser_constructor(self, gchooser): pass
     def gchooser_add_item(self, gchooser, item): pass
     def gchooser_get_selected_item(self, gchooser): pass

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -61,7 +61,7 @@ class TkWindow:
         self._master.protocol("WM_DELETE_WINDOW", self._close)
         self._master.resizable(width=False, height=False)  # Disable resizing by default.
 
-        # Raise the master to be the top window.
+        # For testing: Raise the master to be the top window.
         #self._master.wm_attributes("-topmost", 1)  # TODO(sredmond): Is this really necessary?
         #self._master.lift()
         #self._master.focus_force()
@@ -833,11 +833,10 @@ class TkBackend(GraphicsBackendBase):
 
         win = self._windows[-1]
         gtextfield._tkin = win
-
-        gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)
-        gtextfield._tkobj.pack()
-
-        win._master.update_idletasks()
+        
+        gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)#, 
+                                     #state=tk.NORMAL if not gtextfield._disabled else tk.DISABLED)
+        #win._master.update_idletasks() # Doesn't seem necessary
 
     def gtextfield_get_text(self, gtextfield): 
         return gtextfield._tkobj.get()

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -62,9 +62,9 @@ class TkWindow:
         self._master.resizable(width=False, height=False)  # Disable resizing by default.
 
         # Raise the master to be the top window.
-        self._master.wm_attributes("-topmost", 1)  # TODO(sredmond): Is this really necessary?
-        self._master.lift()
-        self._master.focus_force()
+        #self._master.wm_attributes("-topmost", 1)  # TODO(sredmond): Is this really necessary?
+        #self._master.lift()
+        #self._master.focus_force()
 
         # TODO(sredmond): On macOS, multiple backends might race to set the process-level menu bar.
         setup_menubar(self._master)
@@ -834,7 +834,7 @@ class TkBackend(GraphicsBackendBase):
         win = self._windows[-1]
         gtextfield._tkin = win
 
-        gtextfield._tkobj = tk.Entry(win._master, width=40, name=gtextfield.label, borderwidth=2)
+        gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)
         gtextfield._tkobj.pack()
 
         win._master.update_idletasks()

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -786,10 +786,10 @@ class TkBackend(GraphicsBackendBase):
             gint._tkobj = tk.Button(frame, text=gint.label, command=gint.click,
             state=tk.NORMAL if not gint.disabled else tk.DISABLED)
 
-        if is_north_south:
+        if is_north_south: # Pack things left to right in north and south
             gint._tkobj.pack(side=tk.LEFT)
             #gint._tkobj.grid(row=0, column=frame.grid_size()[1]) # How it would work with grid
-        else:
+        else: # Pack things top to bottom in west and east
             gint._tkobj.pack()
 
         frame.update_idletasks()

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -780,17 +780,14 @@ class TkBackend(GraphicsBackendBase):
             
         if isinstance(gint, GTextField):
             gint._tkobj = tk.Entry(frame, width=40, borderwidth=2) 
-            print("I am text field")
 
         if isinstance(gint, GButton):
             # TODO(sredmond): Wrap up a GActionEvent on the Tk side to supply.
             gint._tkobj = tk.Button(frame, text=gint.label, command=gint.click,
             state=tk.NORMAL if not gint.disabled else tk.DISABLED)
-            print("I am button")
 
-        if is_north_south:
-            print(frame.grid_size()[1])
-            gint._tkobj.grid(row=0, column=frame.grid_size()[1])#side=tk.RIGHT) # FIXME
+        if is_north_south: # Use grid manager to add widgets left to right in north/south
+            gint._tkobj.grid(row=0, column=frame.grid_size()[1]) 
         else:
             gint._tkobj.pack()
 

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -264,13 +264,13 @@ class TkBackend(GraphicsBackendBase):
     def gwindow_add_to_region(self, gwindow, gobject, region):
         from campy.graphics.gwindow import Region
         if region == Region.NORTH:
-            self._ginteractor_add(gobject, gwindow._tkwin.top)
+            self._ginteractor_add(gobject, gwindow._tkwin.top, True)
         if region == Region.EAST:
-            self._ginteractor_add(gobject, gwindow._tkwin.right)
+            self._ginteractor_add(gobject, gwindow._tkwin.right, False)
         if region == Region.SOUTH:
-            self._ginteractor_add(gobject, gwindow._tkwin.bottom)
+            self._ginteractor_add(gobject, gwindow._tkwin.bottom, True)
         if region == Region.WEST:
-            self._ginteractor_add(gobject, gwindow._tkwin.left)
+            self._ginteractor_add(gobject, gwindow._tkwin.left, False)
 
     def gwindow_remove_from_region(self, gwindow, gobject, region): pass
     def gwindow_set_region_alignment(self, gwindow, region, align): pass
@@ -775,13 +775,20 @@ class TkBackend(GraphicsBackendBase):
     ###############
     # Interactors #
     ###############
-    def _ginteractor_add(self, gint, frame):
-        from campy.gui.ginteractors import GButton
+    def _ginteractor_add(self, gint, frame, is_north_south):
+        from campy.gui.ginteractors import GButton, GTextField
         if isinstance(gint, GButton):
             # TODO(sredmond): Wrap up a GActionEvent on the Tk side to supply.
             gint._tkobj = tk.Button(frame, text=gint.label, command=gint.click,
             state=tk.NORMAL if not gint.disabled else tk.DISABLED)
-        gint._tkobj.pack()
+        
+        if isinstance(gint, GTextField):
+            gint._tkobj = tk.Entry(frame, width=40, borderwidth=2) 
+
+        if is_north_south:
+            gint._tkobj.pack(side=tk.RIGHT) # FIXME
+        else:
+            gint._tkobj.pack()
 
         frame.update_idletasks()
 
@@ -833,7 +840,7 @@ class TkBackend(GraphicsBackendBase):
 
         win = self._windows[-1]
         gtextfield._tkin = win
-        
+
         gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)#, 
                                      #state=tk.NORMAL if not gtextfield._disabled else tk.DISABLED)
         #win._master.update_idletasks() # Doesn't seem necessary

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -860,7 +860,8 @@ class TkBackend(GraphicsBackendBase):
         return gtextfield._tkobj.get()
 
     def gtextfield_set_enter_event(self, gtextfield, fn):
-        gtextfield._tkobj.bind("<Return>", lambda event: fn(event))
+        gtextfield._tkobj.bind("<Return>", lambda event: fn())
+        # Removed requirement for fn to take event since it's not really necessary
 
     def gtextfield_set_text(self, gtextfield, str): pass
     def gchooser_constructor(self, gchooser): pass

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -133,18 +133,26 @@ class TkWindow:
     def clear(self):
         # Delete all canvas elements and all interactors, but leave the canvas and interactor regions in place."""
         self.clear_canvas()
+
+        # Since each interactor_area.children is a dictionary, must move to a list first before
+        # clearing dictionary destroying the individual items
+        interactors_to_remove = []
         if self._top:
-            for child in self._top.children:
-                child.destroy()
+            interactors_to_remove += [child[1] for child in self._top.children.items()]
+            self._top.children.clear()
         if self._bottom:
-            for child in self._bottom.children:
-                child.destroy()
+            interactors_to_remove += [child[1] for child in self._bottom.children.items()]
+            self._bottom.children.clear()
         if self._left:
-            for child in self._left.children:
-                child.destroy()
+            interactors_to_remove += [child[1] for child in self._left.children.items()]
+            self._left.children.clear()
         if self._right:
-            for child in self._right.children:
-                child.destroy()
+            interactors_to_remove += [child[1] for child in self._right.children.items()]
+            self._right.children.clear()
+
+        while (len(interactors_to_remove) > 0):
+            interactors_to_remove[0].destroy()
+            interactors_to_remove.pop(0)
 
     def clear_canvas(self):
         # Delete all canvas elements, but leave the canvas (and all interactor regions) in place.

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -817,7 +817,6 @@ class TkBackend(GraphicsBackendBase):
 
         win._master.update_idletasks()
 
-
     def gcheckbox_is_selected(self, gcheckbox):
         return bool(gcheckbox._tkobj.var.get())
 
@@ -828,7 +827,7 @@ class TkBackend(GraphicsBackendBase):
     def gslider_get_value(self, gslider): pass
     def gslider_set_value(self, gslider, value): pass
 
-    def gtextfield_constructor(self, gtextfield):  # FIXME
+    def gtextfield_constructor(self, gtextfield):
         if hasattr(gtextfield, '_tkwin'):
             return
 
@@ -839,7 +838,6 @@ class TkBackend(GraphicsBackendBase):
         gtextfield._tkobj.pack()
 
         win._master.update_idletasks()
-
 
     def gtextfield_get_text(self, gtextfield): 
         return gtextfield._tkobj.get()

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -840,7 +840,7 @@ class TkBackend(GraphicsBackendBase):
             return
 
         win = self._windows[-1]
-        gtextfield._tkin = win
+        gtextfield._tkwin = win
 
         # If we want to be able to call functions on the interactor before it renders
         # (e.g. add_enter_handler), the below line is necessary. Otherwise, just 

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -777,16 +777,20 @@ class TkBackend(GraphicsBackendBase):
     ###############
     def _ginteractor_add(self, gint, frame, is_north_south):
         from campy.gui.ginteractors import GButton, GTextField
+            
+        if isinstance(gint, GTextField):
+            gint._tkobj = tk.Entry(frame, width=40, borderwidth=2) 
+            print("I am text field")
+
         if isinstance(gint, GButton):
             # TODO(sredmond): Wrap up a GActionEvent on the Tk side to supply.
             gint._tkobj = tk.Button(frame, text=gint.label, command=gint.click,
             state=tk.NORMAL if not gint.disabled else tk.DISABLED)
-        
-        if isinstance(gint, GTextField):
-            gint._tkobj = tk.Entry(frame, width=40, borderwidth=2) 
+            print("I am button")
 
         if is_north_south:
-            gint._tkobj.pack(side=tk.RIGHT) # FIXME
+            print(frame.grid_size()[1])
+            gint._tkobj.grid(row=0, column=frame.grid_size()[1])#side=tk.RIGHT) # FIXME
         else:
             gint._tkobj.pack()
 
@@ -841,9 +845,10 @@ class TkBackend(GraphicsBackendBase):
         win = self._windows[-1]
         gtextfield._tkin = win
 
-        gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)#, 
-                                     #state=tk.NORMAL if not gtextfield._disabled else tk.DISABLED)
-        #win._master.update_idletasks() # Doesn't seem necessary
+        # If we want to be able to call functions on the interactor before it renders
+        # (e.g. add_enter_handler), the below line is necessary. Otherwise, just 
+        # tell students they have to add_to_region before calling methods on the interactor.
+        #gtextfield._tkobj = tk.Entry(win._master, width=40, borderwidth=2)
 
     def gtextfield_get_text(self, gtextfield): 
         return gtextfield._tkobj.get()

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -786,8 +786,9 @@ class TkBackend(GraphicsBackendBase):
             gint._tkobj = tk.Button(frame, text=gint.label, command=gint.click,
             state=tk.NORMAL if not gint.disabled else tk.DISABLED)
 
-        if is_north_south: # Use grid manager to add widgets left to right in north/south
-            gint._tkobj.grid(row=0, column=frame.grid_size()[1]) 
+        if is_north_south:
+            gint._tkobj.pack(side=tk.LEFT)
+            #gint._tkobj.grid(row=0, column=frame.grid_size()[1]) # How it would work with grid
         else:
             gint._tkobj.pack()
 

--- a/campy/private/backends/tk/backend_tk.py
+++ b/campy/private/backends/tk/backend_tk.py
@@ -827,8 +827,26 @@ class TkBackend(GraphicsBackendBase):
     def gslider_constructor(self, gslider, min, max, value): pass
     def gslider_get_value(self, gslider): pass
     def gslider_set_value(self, gslider, value): pass
-    def gtextfield_constructor(self, gtextfield, num_chars): pass
-    def gtextfield_get_text(self, gtextfield): pass
+
+    def gtextfield_constructor(self, gtextfield):  # FIXME
+        if hasattr(gtextfield, '_tkwin'):
+            return
+
+        win = self._windows[-1]
+        gtextfield._tkin = win
+
+        gtextfield._tkobj = tk.Entry(win._master, width=40, name=gtextfield.label, borderwidth=2)
+        gtextfield._tkobj.pack()
+
+        win._master.update_idletasks()
+
+
+    def gtextfield_get_text(self, gtextfield): 
+        return gtextfield._tkobj.get()
+
+    def gtextfield_set_enter_event(self, gtextfield, fn):
+        gtextfield._tkobj.bind("<Return>", lambda event: fn(event))
+
     def gtextfield_set_text(self, gtextfield, str): pass
     def gchooser_constructor(self, gchooser): pass
     def gchooser_add_item(self, gchooser, item): pass


### PR DESCRIPTION
**Changes made:**
- Implements GTextField constructor, ability to get text, and adding a callback event for return key.
- Fixes issue with clearing the window erroring when interactors are on the screen.
- Adds a GWindow method for just clearing the canvas (calls existing backend function).
- Remove need for GEvents for interactor callbacks since these functions can be associated with a specific interactor in TK (in Java, event needed to distinguish which interactor the event occured on)

**Decisions about general conventions/structure:**
- Tell students that interactors in NORTH/SOUTH will get added left to right while WEST/EAST will get added top to bottom. They must add them in order when calling add_to_region().
- Have campy functions parallel tk as much as possible
- GInteractors shouldn't need events passed into their callback functions (unnecessary for student functionality with TK)

Currently working for NameSurfer (program not included in PR).

---STILL IN PROGRESS---
**Need to fix:**
- GTextField: string passed in doesn't currently do anything
- Add scrollable text/label object specifically for interactor regions (e.g. for searching name substrings in BabyNames)

**Nice to have:**
- Ability to center interactors within a region (maybe specify property align=left/center/right for the region?)